### PR TITLE
add markdown header tags to 'html' regex

### DIFF
--- a/titlecase.php
+++ b/titlecase.php
@@ -7,7 +7,7 @@
 function titleCase ($title) {
 	//remove HTML, storing it for later
 	//       HTML elements to ignore    | tags  | entities
-	$regx = '/<(code|var)[^>]*>.*?<\/\1>|<[^>]+>|&\S+;/';
+	$regx = '/<(code|var)[^>]*>.*?<\/\1>|<[^>]+>|&\S+;|(#+ )/';
 	preg_match_all ($regx, $title, $html, PREG_OFFSET_CAPTURE);
 	$title = preg_replace ($regx, '', $title);
 	


### PR DESCRIPTION
This allows for the proper title casing of markdown header tags
